### PR TITLE
Fix travis build - fix #9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,19 @@ matrix:
     include:
         - php: 7.0
           env: check_cs=true
+        - php: 7.0
+          env: deps=low
+        - php: 7.1
+          env: deps=high
 
 env:
     global:
+        - deps=high
         - check_cs=false
+
+install:
+    - if [ "$deps" = "low" ]; then composer --prefer-dist --prefer-lowest update; fi;
+    - if [ "$deps" != "low" ]; then composer --prefer-dist update; fi;
 
 before_script:
     - composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
         "symfony/config": "~2.7|~3.0",
         "symfony/dependency-injection": "~2.7|~3.0",
         "symfony/yaml": "~2.7|~3.0",
-        "symfony/framework-bundle": "~2.7|~3.0",
+        "symfony/framework-bundle": "~2.7.25|~2.8.15|~3.0",
         "symfony/twig-bundle": "~2.7|~3.0",
-        "doctrine/orm": "~2.4",
+        "doctrine/orm": "~2.5",
         "doctrine/doctrine-bundle": "~1.6"
     },
     "extra": {

--- a/tests/Functional/Fixtures/symfony/.gitignore
+++ b/tests/Functional/Fixtures/symfony/.gitignore
@@ -1,4 +1,5 @@
 /app/data/*
+!/app/data/.gitkeep
 /var/*
 !/var/cache
 /var/cache/*

--- a/tests/Functional/Fixtures/symfony/app/AppKernel.php
+++ b/tests/Functional/Fixtures/symfony/app/AppKernel.php
@@ -36,6 +36,10 @@ class AppKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load($this->getRootDir().'/config/config.yml');
+        if (version_compare(self::VERSION, '3.0.0', '<')) {
+            $loader->load($this->getRootDir().'/config/config_lower_than_3-0.yml');
+        } else {
+            $loader->load($this->getRootDir().'/config/config_greater_than_3-0.yml');
+        }
     }
 }

--- a/tests/Functional/Fixtures/symfony/app/config/config.yml
+++ b/tests/Functional/Fixtures/symfony/app/config/config.yml
@@ -3,10 +3,6 @@ framework:
     router:
         resource: '%kernel.root_dir%/config/routing.yml'
         strict_requirements: ~
-    templating:
-        enabled: false
-    assets:
-        enabled: false
     session:
         # http://symfony.com/doc/current/reference/configuration/framework.html#handler-id
         handler_id:  session.handler.native_file

--- a/tests/Functional/Fixtures/symfony/app/config/config_greater_than_3-0.yml
+++ b/tests/Functional/Fixtures/symfony/app/config/config_greater_than_3-0.yml
@@ -1,0 +1,8 @@
+imports:
+    - { resource: config.yml }
+
+framework:
+    templating:
+        enabled: false
+    assets:
+        enabled: false

--- a/tests/Functional/Fixtures/symfony/app/config/config_lower_than_3-0.yml
+++ b/tests/Functional/Fixtures/symfony/app/config/config_lower_than_3-0.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: config.yml }
+
+framework:
+    templating:
+        engines: ['twig']


### PR DESCRIPTION
I finally decided to not build against hhvm because it was not really adopted by the ecosystem and even Symfony will remove support for it soon