### PR TITLE
Do not run if the response is empty or false, like BinaryResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not yet released
 
+* Fix support for BinaryFileResponse and other empty content Responses
+
 ## 0.3.0 (2017-08-18)
 
 * Tweak tests

--- a/src/Bridge/Symfony/Subscriber/SeoSubscriber.php
+++ b/src/Bridge/Symfony/Subscriber/SeoSubscriber.php
@@ -37,6 +37,10 @@ class SeoSubscriber implements EventSubscriberInterface
 
             $responseContent = $event->getResponse()->getContent();
 
+            if (!$responseContent) {
+                return;
+            }
+
             if ($event->getResponse()->getStatusCode() >= 300) {
                 // We do not want to trigger fetchers on non 2XX response
                 $newResponseContent = $this->seoManager->overrideHtml($responseContent);

--- a/tests/Functional/Fixtures/symfony/app/config/routing.yml
+++ b/tests/Functional/Fixtures/symfony/app/config/routing.yml
@@ -8,3 +8,8 @@ error:
     path: /error
     defaults:
         _controller: app.error_controller:errorAction
+
+download:
+    path: /download
+    defaults:
+        _controller: app.error_controller:downloadAction

--- a/tests/Functional/Fixtures/symfony/src/Controller/ErrorController.php
+++ b/tests/Functional/Fixtures/symfony/src/Controller/ErrorController.php
@@ -3,6 +3,7 @@
 namespace Joli\SeoOverride\Tests\Functional\Fixtures\symfony\src\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 class ErrorController extends Controller
@@ -10,5 +11,15 @@ class ErrorController extends Controller
     public function errorAction()
     {
         return new Response($this->renderView('error.html.twig'), 400);
+    }
+
+    public function downloadAction()
+    {
+        $tmpfname = tempnam("/tmp", "FOO");
+        $handle = fopen($tmpfname, "w");
+        fwrite($handle, "🎅");
+        fclose($handle);
+
+        return new BinaryFileResponse($tmpfname);
     }
 }

--- a/tests/Functional/Fixtures/symfony/src/Controller/ErrorController.php
+++ b/tests/Functional/Fixtures/symfony/src/Controller/ErrorController.php
@@ -16,9 +16,6 @@ class ErrorController extends Controller
     public function downloadAction()
     {
         $tmpfname = tempnam("/tmp", "FOO");
-        $handle = fopen($tmpfname, "w");
-        fwrite($handle, "🎅");
-        fclose($handle);
 
         return new BinaryFileResponse($tmpfname);
     }

--- a/tests/Functional/SymfonyTest.php
+++ b/tests/Functional/SymfonyTest.php
@@ -164,7 +164,7 @@ HTML;
         $response = $this->call('/download', 'localhost');
 
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('🎅', $response->getContent());
+        $this->assertSame(false, $response->getContent());
     }
 
     protected static function getKernelClass()

--- a/tests/Functional/SymfonyTest.php
+++ b/tests/Functional/SymfonyTest.php
@@ -159,6 +159,14 @@ HTML;
         $this->assertSame($expected, $response->getContent());
     }
 
+    public function test_it_does_not_override_seo_when_no_content_or_binary_response()
+    {
+        $response = $this->call('/download', 'localhost');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('🎅', $response->getContent());
+    }
+
     protected static function getKernelClass()
     {
         return AppKernel::class;


### PR DESCRIPTION
Add a check on the response content before running anything. The response content can be empty, or false in case of BinaryFileResponse.