### PR TITLE
Add DataCollector reset() method for Symfony 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes between versions
 
+## Unreleased
+
+* Fix Symfony 3.4 / 4.0 compatibility with DataCollector
+
 ## 0.5.0 (2017-10-12)
 
 * [BC BREAK] Remove SeoManagerInterface

--- a/src/Bridge/Symfony/DataCollector/SeoOverrideDataCollector.php
+++ b/src/Bridge/Symfony/DataCollector/SeoOverrideDataCollector.php
@@ -60,7 +60,7 @@ class SeoOverrideDataCollector extends DataCollector implements LateDataCollecto
      */
     public function reset()
     {
-        $this->data = array();
+        $this->data = [];
     }
 
     public function getFetchers()

--- a/src/Bridge/Symfony/DataCollector/SeoOverrideDataCollector.php
+++ b/src/Bridge/Symfony/DataCollector/SeoOverrideDataCollector.php
@@ -55,6 +55,14 @@ class SeoOverrideDataCollector extends DataCollector implements LateDataCollecto
     {
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->data = array();
+    }
+
     public function getFetchers()
     {
         return $this->data['fetchers'];

--- a/src/Bridge/Symfony/Resources/config/debug.yml
+++ b/src/Bridge/Symfony/Resources/config/debug.yml
@@ -9,6 +9,7 @@ services:
             - '%seo_override.domains%'
             - ~
             - '%seo_override.fetchers_mapping%'
+        public: true
 
     seo_override.data_collector:
         class: Joli\SeoOverride\Bridge\Symfony\DataCollector\SeoOverrideDataCollector

--- a/tests/Functional/Fixtures/symfony/app/config/config.yml
+++ b/tests/Functional/Fixtures/symfony/app/config/config.yml
@@ -1,6 +1,7 @@
 services:
     app.controller:
         class: Joli\SeoOverride\Tests\Functional\Fixtures\symfony\src\Controller\AppController
+        public: true
         calls:
             - [setContainer, ["@service_container"]]
 

--- a/tests/Functional/SymfonyTest.php
+++ b/tests/Functional/SymfonyTest.php
@@ -143,7 +143,7 @@ HTML;
         $response = $this->call('/download', 'localhost');
 
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame(false, $response->getContent());
+        $this->assertFalse($response->getContent());
     }
 
     public function test_it_does_not_override_seo_when_no_2XX_response()


### PR DESCRIPTION
Ref #30 

It's deprecated not to have this method:

> User Deprecated: Implementing "Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface" without the "reset()" method is deprecated since version 3.4 and will be unsupported in 4.0 for class "Joli\SeoOverride\Bridge\Symfony\DataCollector\SeoOverrideDataCollector".