### PR TITLE
Fix MySQL error for column 'path' without length used in an index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Drop compatibility with Symfony < 3.0
 * Add compatibility with Symfony 4.0
 * [BC BREAK][Doctrine] Changed SeoOverride SQL index to use a hash of the path
+(you should update your database schema due to SQL column and index changes)
 
 ## 0.5.1 (2017-12-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Drop compatibility with Symfony < 3.0
 * Add compatibility with Symfony 4.0
-* [BC BREAK][Doctrine] Changed SeoOverride SQL index to use a md5 of the path
+* [BC BREAK][Doctrine] Changed SeoOverride SQL index to use a hash of the path
 
 ## 0.5.1 (2017-12-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Not yet released
 
-* Dropped compatibility with Symfony < 3.0
-* Added compatibility with Symfony 4.0
+* Drop compatibility with Symfony < 3.0
+* Add compatibility with Symfony 4.0
+* [BC BREAK][Doctrine] Changed SeoOverride SQL index to use a md5 of the path
 
 ## 0.5.1 (2017-12-28)
 

--- a/src/Bridge/Doctrine/Entity/SeoOverride.php
+++ b/src/Bridge/Doctrine/Entity/SeoOverride.php
@@ -51,7 +51,7 @@ class SeoOverride
     public function setPath(string $path)
     {
         $this->path = $path;
-        $this->hashedPath = md5($path);
+        $this->hashedPath = sha1($path);
     }
 
     public function getHashedPath()

--- a/src/Bridge/Doctrine/Entity/SeoOverride.php
+++ b/src/Bridge/Doctrine/Entity/SeoOverride.php
@@ -24,6 +24,11 @@ class SeoOverride
     private $path;
 
     /**
+     * @var string
+     */
+    private $hashedPath;
+
+    /**
      * @var string|null
      */
     private $domainAlias;
@@ -46,6 +51,12 @@ class SeoOverride
     public function setPath(string $path)
     {
         $this->path = $path;
+        $this->hashedPath = md5($path);
+    }
+
+    public function getHashedPath()
+    {
+        return $this->hashedPath;
     }
 
     public function getDomainAlias()

--- a/src/Bridge/Doctrine/Repository/SeoOverrideRepository.php
+++ b/src/Bridge/Doctrine/Repository/SeoOverrideRepository.php
@@ -23,7 +23,7 @@ class SeoOverrideRepository extends EntityRepository
     {
         return $this->createQueryBuilder('s')
              ->andWhere('s.hashedPath = :hashedPath')
-             ->setParameter('hashedPath', md5($path))
+             ->setParameter('hashedPath', sha1($path))
              ->andWhere('s.domainAlias = :domainAlias')
              ->setParameter('domainAlias', $domainAlias)
              ->setMaxResults(1)

--- a/src/Bridge/Doctrine/Repository/SeoOverrideRepository.php
+++ b/src/Bridge/Doctrine/Repository/SeoOverrideRepository.php
@@ -22,12 +22,13 @@ class SeoOverrideRepository extends EntityRepository
     public function findOneForPathAndDomain(string $path, string $domainAlias = null)
     {
         return $this->createQueryBuilder('s')
-             ->andWhere('s.path = :path')
-             ->setParameter('path', $path)
+             ->andWhere('s.hashedPath = :hashedPath')
+             ->setParameter('hashedPath', md5($path))
              ->andWhere('s.domainAlias = :domainAlias')
              ->setParameter('domainAlias', $domainAlias)
              ->setMaxResults(1)
              ->getQuery()
-             ->getOneOrNullResult();
+             ->getOneOrNullResult()
+        ;
     }
 }

--- a/src/Bridge/Doctrine/Resources/config/doctrine/SeoOverride.orm.yml
+++ b/src/Bridge/Doctrine/Resources/config/doctrine/SeoOverride.orm.yml
@@ -4,7 +4,7 @@ Joli\SeoOverride\Bridge\Doctrine\Entity\SeoOverride:
   table: joli_seo_override
   indexes:
     request_index:
-      columns: [ path, domain_alias ]
+      columns: [ hashed_path, domain_alias ]
   id:
     id:
       type: integer
@@ -14,6 +14,10 @@ Joli\SeoOverride\Bridge\Doctrine\Entity\SeoOverride:
     path:
       column: path
       type: text
+    hashedPath:
+      column: hashed_path
+      type: string
+      length: 32
     domainAlias:
       column: domain_alias
       type: string

--- a/src/Bridge/Doctrine/Resources/config/doctrine/SeoOverride.orm.yml
+++ b/src/Bridge/Doctrine/Resources/config/doctrine/SeoOverride.orm.yml
@@ -17,7 +17,7 @@ Joli\SeoOverride\Bridge\Doctrine\Entity\SeoOverride:
     hashedPath:
       column: hashed_path
       type: string
-      length: 32
+      length: 40
     domainAlias:
       column: domain_alias
       type: string


### PR DESCRIPTION
##  Fix the following error:
```
SQLSTATE[42000]: Syntax error or access violation: 1170 BLOB/TEXT column
'path' used in key specification without a key length
```

The Doctrine bridge now uses a hash of the path to avoid this error.

## Old description, just for reference:

~~I would have prefered to use a standard 2048 char limit for the `path` but MySQL return an error when the column length is >= 770:~~

~~SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was
too long; max key length is 3072 bytes~~

 :man_shrugging: