### PR TITLE
Use is null instead of equals null (SQL)

### DIFF
--- a/src/Bridge/Doctrine/Repository/SeoOverrideRepository.php
+++ b/src/Bridge/Doctrine/Repository/SeoOverrideRepository.php
@@ -18,8 +18,6 @@ use Joli\SeoOverride\Bridge\Doctrine\Entity\SeoOverride;
 class SeoOverrideRepository extends EntityRepository
 {
     /**
-     * @throws NonUniqueResultException
-     *
      * @return SeoOverride|null
      */
     public function findOneForPathAndDomain(string $path, string $domainAlias = null)

--- a/src/Bridge/Doctrine/Repository/SeoOverrideRepository.php
+++ b/src/Bridge/Doctrine/Repository/SeoOverrideRepository.php
@@ -12,7 +12,6 @@
 namespace Joli\SeoOverride\Bridge\Doctrine\Repository;
 
 use Doctrine\ORM\EntityRepository;
-use Doctrine\ORM\NonUniqueResultException;
 use Joli\SeoOverride\Bridge\Doctrine\Entity\SeoOverride;
 
 class SeoOverrideRepository extends EntityRepository
@@ -33,8 +32,7 @@ class SeoOverrideRepository extends EntityRepository
                 ->setParameter('domainAlias', $domainAlias);
         }
 
-        return $qb->setMaxResults(1)
-            ->getQuery()
+        return $qb->getQuery()
             ->getOneOrNullResult();
     }
 }

--- a/src/Bridge/Doctrine/Repository/SeoOverrideRepository.php
+++ b/src/Bridge/Doctrine/Repository/SeoOverrideRepository.php
@@ -12,11 +12,14 @@
 namespace Joli\SeoOverride\Bridge\Doctrine\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\NonUniqueResultException;
 use Joli\SeoOverride\Bridge\Doctrine\Entity\SeoOverride;
 
 class SeoOverrideRepository extends EntityRepository
 {
     /**
+     * @throws NonUniqueResultException
+     *
      * @return SeoOverride|null
      */
     public function findOneForPathAndDomain(string $path, string $domainAlias = null)
@@ -25,17 +28,15 @@ class SeoOverrideRepository extends EntityRepository
             ->andWhere('s.hashedPath = :hashedPath')
             ->setParameter('hashedPath', sha1($path));
 
-        if ($domainAlias === null) {
-                $qb->andWhere('s.domainAlias IS NULL');
+        if (null === $domainAlias) {
+            $qb->andWhere('s.domainAlias IS NULL');
         } else {
-            $qb ->andWhere('s.domainAlias = :domainAlias')
+            $qb->andWhere('s.domainAlias = :domainAlias')
                 ->setParameter('domainAlias', $domainAlias);
         }
 
-        $qb->setMaxResults(1)
+        return $qb->setMaxResults(1)
             ->getQuery()
             ->getOneOrNullResult();
-
-        return $qb;
     }
 }

--- a/src/Bridge/Doctrine/Repository/SeoOverrideRepository.php
+++ b/src/Bridge/Doctrine/Repository/SeoOverrideRepository.php
@@ -32,7 +32,8 @@ class SeoOverrideRepository extends EntityRepository
                 ->setParameter('domainAlias', $domainAlias);
         }
 
-        return $qb->getQuery()
+        return $qb->setMaxResults(1)
+            ->getQuery()
             ->getOneOrNullResult();
     }
 }

--- a/src/Bridge/Doctrine/Repository/SeoOverrideRepository.php
+++ b/src/Bridge/Doctrine/Repository/SeoOverrideRepository.php
@@ -21,14 +21,21 @@ class SeoOverrideRepository extends EntityRepository
      */
     public function findOneForPathAndDomain(string $path, string $domainAlias = null)
     {
-        return $this->createQueryBuilder('s')
-             ->andWhere('s.hashedPath = :hashedPath')
-             ->setParameter('hashedPath', sha1($path))
-             ->andWhere('s.domainAlias = :domainAlias')
-             ->setParameter('domainAlias', $domainAlias)
-             ->setMaxResults(1)
-             ->getQuery()
-             ->getOneOrNullResult()
-        ;
+        $qb = $this->createQueryBuilder('s')
+            ->andWhere('s.hashedPath = :hashedPath')
+            ->setParameter('hashedPath', sha1($path));
+
+        if ($domainAlias === null) {
+                $qb->andWhere('s.domainAlias IS NULL');
+        } else {
+            $qb ->andWhere('s.domainAlias = :domainAlias')
+                ->setParameter('domainAlias', $domainAlias);
+        }
+
+        $qb->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $qb;
     }
 }


### PR DESCRIPTION
Fix SQL wrong query 

## Details
When use `= NULL`, result is not good. Use `IS NULL` instead.

- Tests are good 👍
- Run CS-Fixer 👍

⚠️ Wait until [this PR](https://github.com/jolicode/seo-override/pull/40) is close.