### PR TITLE
Replace lazy by possessive quantifiers

### DIFF
--- a/src/SeoManager.php
+++ b/src/SeoManager.php
@@ -117,13 +117,13 @@ class SeoManager
 
         return preg_replace(
             [
-                '@<!--SEO_TITLE-->(.+)<!--/SEO_TITLE-->@ims',
-                '@<!--SEO_DESCRIPTION-->(.*?)<!--/SEO_DESCRIPTION-->@ims',
-                '@<!--SEO_KEYWORDS-->(.*?)<!--/SEO_KEYWORDS-->@ims',
-                '@<!--SEO_ROBOTS-->(.*?)<!--/SEO_ROBOTS-->@ims',
-                '@<!--SEO_CANONICAL-->(.*?)<!--/SEO_CANONICAL-->@ims',
-                '@<!--SEO_OG_TITLE-->(.*?)<!--/SEO_OG_TITLE-->@ims',
-                '@<!--SEO_OG_DESCRIPTION-->(.*?)<!--/SEO_OG_DESCRIPTION-->@ims',
+                '@<!--SEO_TITLE-->(.++)<!--/SEO_TITLE-->@ims',
+                '@<!--SEO_DESCRIPTION-->(.*+)<!--/SEO_DESCRIPTION-->@ims',
+                '@<!--SEO_KEYWORDS-->(.*+)<!--/SEO_KEYWORDS-->@ims',
+                '@<!--SEO_ROBOTS-->(.*+)<!--/SEO_ROBOTS-->@ims',
+                '@<!--SEO_CANONICAL-->(.*+)<!--/SEO_CANONICAL-->@ims',
+                '@<!--SEO_OG_TITLE-->(.*+)<!--/SEO_OG_TITLE-->@ims',
+                '@<!--SEO_OG_DESCRIPTION-->(.*+)<!--/SEO_OG_DESCRIPTION-->@ims',
             ],
             [
                 $seo->getTitle() ? '<title>'.$this->encodeHtmlChars($seo->getTitle()).'</title>' : '$1',


### PR DESCRIPTION
Fix #43 

I didn’t really understand backtracking and how possessive quantifiers avoid it but it indeed suppresses the `PREG_BACKTRACK_LIMIT_ERROR`.