### PR TITLE
fix(ea4): Prevents PropertyAccessor error when using SeoOverride with EasyAdmin 4

### DIFF
--- a/src/Bridge/Doctrine/Entity/SeoOverride.php
+++ b/src/Bridge/Doctrine/Entity/SeoOverride.php
@@ -38,6 +38,11 @@ class SeoOverride
      */
     private $seo;
 
+    public function __construct()
+    {
+        $this->seo = new Seo;
+    }
+
     public function getId()
     {
         return $this->id;


### PR DESCRIPTION
I got this error on a project using Easy Admin, after updating it to EA4+, when trying to create a new SEO rule.

> PropertyAccessor requires a graph of objects or arrays to operate on, but it found type "NULL" while trying to traverse path "seo.title" at property "title".

This constructor fixes the issue as the properties are not empty anymore.